### PR TITLE
[Fix]: Make directory for logs if not exist, handle AutoCAD error.

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,5 +1,4 @@
-__pycache__
-venv
+__pycache__/
+venv/
 *.bak
-logs/*.log
-!logs/.gitkeep
+logs/

--- a/core/beams.py
+++ b/core/beams.py
@@ -1,8 +1,11 @@
 from core.autocad_controller import AutoCADController
 
-acadModel = AutoCADController()
+acadModel = AutoCADController(__name__)
 
 def draw_beam_outline(beam_data, layer_name, origin=(0, 0)):
+    
+    if acadModel.acad == None:
+        return
     
     # Draw outline
     for beam_name in beam_data:

--- a/core/layer_manager.py
+++ b/core/layer_manager.py
@@ -1,7 +1,7 @@
 from core.autocad_controller import AutoCADController
 from utils.json_loader import color_map
 
-acadModel = AutoCADController()
+acadModel = AutoCADController(__name__)
 
 def setup_layers(layers_data: dict) -> None:
     """Create the layers and assign name, color and linetype for each
@@ -9,6 +9,9 @@ def setup_layers(layers_data: dict) -> None:
     Args:
         layers_data (dict): Layers data as dictionary loaded from JSON file or database
     """
+    
+    if acadModel.acad == None:
+        return
     
     for name, props in layers_data.items():
         

--- a/main.py
+++ b/main.py
@@ -11,51 +11,6 @@ def main():
     
     # Beams Manager
     # draw_beam_outline(beams_data,layer_name="0")
-    
-
-"""
-import sys
-from PyQt5.QtWidgets import QApplication, QMainWindow, QLabel
-from utils.messenger import Messenger, MultiMessenger
-from gui.message_handler import QtMessenger
-from utils.file_messager import FileMessenger
-
-class MainWindow(QMainWindow):
-    def __init__(self):
-        super().__init__()
-        self.setWindowTitle("AutoCAD Beam Tool")
-
-        # Set up status bar
-        self.status = self.statusBar()
-        self.status_label = QLabel("")
-        self.status.addPermanentWidget(self.status_label)
-
-        # Set Messenger handler
-        Messenger.set_handler(
-            MultiMessenger(
-                QtMessenger(self.update_status),
-                FileMessenger("logs/app.log)
-            )
-        )
-
-        # Test the setup
-        Messenger.send("Application started", level="info")
-
-    def update_status(self, msg):
-        self.status_label.setText(msg)
-
-if __name__ == "__main__":
-    app = QApplication(sys.argv)
-    win = MainWindow()
-    win.show()
-    sys.exit(app.exec_())
-
-"""
-
-
-
-
-
 
 
     

--- a/utils/handlers.py
+++ b/utils/handlers.py
@@ -1,5 +1,5 @@
+import os
 import logging
-from datetime import datetime
 
 class ConsoleHandler:
     def handle_message(self, message: str, level: str):
@@ -8,8 +8,12 @@ class ConsoleHandler:
 
 class LogFileHandler:
     def __init__(self, log_file="logs/app.log"):
+        
+        self.log_file = log_file
+        
+        os.makedirs(os.path.dirname(self.log_file), exist_ok=True)
         logging.basicConfig(
-            filename=log_file,
+            filename=self.log_file,
             level=logging.DEBUG,
             format='%(asctime)s - %(levelname)s - %(message)s',
             filemode='a'


### PR DESCRIPTION
Remove ```python
self.acad = win32com.client.Dispatch("AutoCAD")```  to not create `AutoCAD` process if not found.

Add error handling for `AutoCAD` errors:
`"Operation unavailable"` when run the program with no `AutoCAD` process running, `"Failed to get the Document object"` when run the program with no `AutoCAD` Document open.

Fix `"FileNotFoundError"` when no logs/ directory found.